### PR TITLE
fix: show initial balance on deploy

### DIFF
--- a/scripts/erc20/deploy.js
+++ b/scripts/erc20/deploy.js
@@ -16,7 +16,7 @@ async function main() {
   });
   console.log({
     name: await token.name(),
-    initialBalance: await token.totalSupply().toString(),
+    initialBalance: (await token.totalSupply()).toString(),
   });
 }
 


### PR DESCRIPTION
Fix displayed `[Object object]` in the console as we didn't `await` on the `totalSupply` but on the `toString` call.